### PR TITLE
Two helper commands, nomenclature, typo cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ ENV/
 
 .idea
 /batchbeagle.yml
+
+# swapfiles
+.*.sw*

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Full documentation at [http://batchbeagle.readthedocs.io](http://batchbeagle.rea
 
 * Create, update, disable and destroy queues
 * Create, update, disable and destroy compute environments
-* Create, update, and deregister job descriptions
+* Create, update, and deregister job definitions
 * Submit, list, cancel and terminate jobs
 * Run multiple jobs by passing a parameters file
 * Specify all allowed values for the parameters
@@ -24,7 +24,7 @@ Full documentation at [http://batchbeagle.readthedocs.io](http://batchbeagle.rea
 To use ``batchbeagle``, you
 
 * Install ``batchbeagle``
-* Define your queues, compute environments, and job descriptions in ``batchbeagle.yml``
+* Define your queues, compute environments, and job definitions in ``batchbeagle.yml``
 * Use ``beagle`` to start managing them
 
 A simple ``batchbeagle.yml`` looks like this:

--- a/batchbeagle/aws/batch.py
+++ b/batchbeagle/aws/batch.py
@@ -701,15 +701,15 @@ class BatchManager(object):
         for queue in self.queues.values():
             queue.update_compute_environments(aws_compute_environments)
 
-    def create_job_description(self, name):
+    def create_job_definition(self, name):
         self.job_definitions[name].register()
         # self.describe()
 
-    def update_job_description(self, name):
+    def update_job_definition(self, name):
         self.job_definitions[name].register()
         # self.describe()
 
-    def deregister_job_description(self, name):
+    def deregister_job_definition(self, name):
         self.job_definitions[name].deregister()
         # self.describe()
 

--- a/batchbeagle/aws/batch.py
+++ b/batchbeagle/aws/batch.py
@@ -917,6 +917,8 @@ class BatchManager(object):
             ]):
                 break
 
+        self.from_aws()
+
         # queues
         queues = set(self.queues.keys())
         for queue in queues:
@@ -926,6 +928,11 @@ class BatchManager(object):
             else:
                 self.update_queue(queue)
 
+        self.from_aws()
+
         # job definitions
         for job_definition in self.job_definitions.keys():
             self.create_job_definition(job_definition)
+
+    def teardown(self):
+        pass

--- a/batchbeagle/dplycli.py
+++ b/batchbeagle/dplycli.py
@@ -251,16 +251,16 @@ def assemble(ctx):
     mgr = BatchManager(filename=ctx.obj['CONFIG_FILE'])
     mgr.assemble()
 
-#@cli.command(short_help='Teardown all Batch resoures defined in a configuration')
-#@click.pass_context
-#def teardown(ctx):
-#    """
-#    Teardown (destroy/deregister) all Job Descriptions, Job Queues and Compute Environments in a config file
-#    :param ctx:
-#    :return:
-#    """
-#    mgr = BatchManager(filename=ctx.obj['CONFIG_FILE'])
-#    mgr.teardown()
+@cli.command(short_help='Teardown all Batch resoures defined in a configuration')
+@click.pass_context
+def teardown(ctx):
+    """
+    Teardown (destroy/deregister) all Job Descriptions, Job Queues and Compute Environments in a config file
+    :param ctx:
+    :return:
+    """
+    mgr = BatchManager(filename=ctx.obj['CONFIG_FILE'])
+    mgr.teardown()
 
 def main():
     cli(obj={})

--- a/batchbeagle/dplycli.py
+++ b/batchbeagle/dplycli.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import copy
 import csv
 import time
 
@@ -70,6 +71,8 @@ def destroy(ctx, queue):
     Destroy an existing queue.
     """
     mgr = BatchManager(filename=ctx.obj['CONFIG_FILE'])
+    mgr.disable_queue(queue)
+    time.sleep(1)
     mgr.destroy_queue(queue)
 
 @cli.group(short_help='Work with Batch Compute Environments.')
@@ -118,22 +121,25 @@ def destroy(ctx, compute_environment):
     """
 
     mgr = BatchManager(filename=ctx.obj['CONFIG_FILE'])
+    mgr.disable_compute_environment(compute_environment)
+    time.sleep(1)
     mgr.destroy_compute_environment(compute_environment)
 
 @cli.group(short_help='Work with Batch Jobs.')
 def job():
     """
-    Sub-command for building and managing Batch job descriptiouns and jobs.
+    Sub-command for building and managing Batch job definitions and jobs.
     """
     pass
 
 @job.command()
 @click.pass_context
 @click.argument('name')
-@click.argument('job_description')
+@click.argument('job_definition')
 @click.argument('queue')
 @click.option('--parameters', '-p', default=None, help="Path to the parameters file.")
-def submit(ctx, name, job_description, queue, parameters):
+@click.option('--nowait', is_flag=True, default=False, help="Do not wait for all jobs to start running")
+def submit(ctx, name, job_definition, queue, parameters, nowait):
     """
     Submit jobs to AWS Batch. Each line of the parameters file will result in a job.
     """
@@ -143,14 +149,14 @@ def submit(ctx, name, job_description, queue, parameters):
             # first line is parameter names
             reader = csv.DictReader(csvfile)
             for row in reader:
-                mgr.submit_job(name, job_description, queue, parameters=row)
+                mgr.submit_job(name, job_definition, queue, parameters=row)
     else:
-        mgr.submit_job(name, job_description, queue)
+        mgr.submit_job(name, job_definition, queue)
     while True:
         lines, runnable_count = mgr.list_jobs(queue)
         for line in lines:
             click.echo(line)
-        if runnable_count == 0:
+        if runnable_count == 0 or nowait:
             break
         time.sleep(5)
 
@@ -203,36 +209,102 @@ def terminate(ctx, queue):
 
 @job.command()
 @click.pass_context
-@click.argument('job_description')
-def create(ctx, job_description):
+@click.argument('job_definition')
+def create(ctx, job_definition):
     """
-    Create a new job description.
+    Create a new job definition.
     """
     mgr = BatchManager(filename=ctx.obj['CONFIG_FILE'])
-    mgr.create_job_description(job_description)
+    mgr.create_job_definition(job_definition)
 
 @job.command()
 @click.pass_context
-@click.argument('job_description')
-def update(ctx, job_description):
+@click.argument('job_definition')
+def update(ctx, job_definition):
     """
-    Update an existing job description.
+    Update an existing job definition.
     """
     mgr = BatchManager(filename=ctx.obj['CONFIG_FILE'])
-    mgr.update_job_description(job_description)
+    mgr.update_job_definition(job_definition)
 
 @job.command()
 @click.pass_context
-@click.argument('job_description')
-def deregister(ctx, job_description):
+@click.argument('job_definition')
+def deregister(ctx, job_definition):
     """
-    Deregister an existing job description.
+    Deregister an existing job definition.
     :param ctx:
-    :param job_description:
+    :param job_definition:
     :return:
     """
     mgr = BatchManager(filename=ctx.obj['CONFIG_FILE'])
-    mgr.deregister_job_description(job_description)
+    mgr.deregister_job_definition(job_definition)
+
+@cli.command(short_help='Teardown all Batch resoures defined in a configuration')
+@click.pass_context
+def teardown(ctx):
+    """
+    Teardown (destroy/deregister) all Job Descriptions, Job Queues and Compute Environments in a config file
+    :param ctx:
+    :return:
+    """
+    mgr = BatchManager(filename=ctx.obj['CONFIG_FILE'])
+
+    # job definitions
+    for job_definition in mgr.job_definitions.keys():
+        mgr.deregister_job_definition(job_definition)
+
+    # job queues
+    # disable
+    queues = [queue for queue in mgr.queues.keys()]
+    for queue in queues:
+        try:
+            mgr.disable_queue(queue)
+        except Exception:
+            pass
+
+    time.sleep(5)
+
+    # delete
+    while len(queues):
+
+        _queues = copy.copy(queues)
+        for queue in _queues:
+            try:
+                mgr.destroy_queue(queue)
+            except Exception:
+                pass
+            else:
+                queues.remove(queue)
+
+        time.sleep(1)
+
+    time.sleep(5)
+
+    # compute environments
+    # disable
+    compute_environments = [compute_environment for compute_environment in mgr.compute_environments.keys()]
+    for compute_environment in compute_environments:
+        try:
+            mgr.disable_compute_environment(compute_environment)
+        except Exception:
+            pass
+
+    time.sleep(5)
+
+    # delete
+    while len(compute_environments):
+
+        _compute_environments = copy.copy(compute_environments)
+        for compute_environment in _compute_environments:
+            try:
+                mgr.destroy_compute_environment(compute_environment)
+            except Exception:
+                pass
+            else:
+                compute_environments.remove(compute_environment)
+
+        time.sleep(1)
 
 def main():
     cli(obj={})

--- a/batchbeagle/dplycli.py
+++ b/batchbeagle/dplycli.py
@@ -240,71 +240,27 @@ def deregister(ctx, job_definition):
     mgr = BatchManager(filename=ctx.obj['CONFIG_FILE'])
     mgr.deregister_job_definition(job_definition)
 
-@cli.command(short_help='Teardown all Batch resoures defined in a configuration')
+@cli.command(short_help='Assemble all Batch resoures defined in a configuration')
 @click.pass_context
-def teardown(ctx):
+def assemble(ctx):
     """
-    Teardown (destroy/deregister) all Job Descriptions, Job Queues and Compute Environments in a config file
+    Assemble (create/update) all Job Descriptions, Job Queues and Compute Environments in a config file
     :param ctx:
     :return:
     """
     mgr = BatchManager(filename=ctx.obj['CONFIG_FILE'])
+    mgr.assemble()
 
-    # job definitions
-    for job_definition in mgr.job_definitions.keys():
-        mgr.deregister_job_definition(job_definition)
-
-    # job queues
-    # disable
-    queues = [queue for queue in mgr.queues.keys()]
-    for queue in queues:
-        try:
-            mgr.disable_queue(queue)
-        except Exception:
-            pass
-
-    time.sleep(5)
-
-    # delete
-    while len(queues):
-
-        _queues = copy.copy(queues)
-        for queue in _queues:
-            try:
-                mgr.destroy_queue(queue)
-            except Exception:
-                pass
-            else:
-                queues.remove(queue)
-
-        time.sleep(1)
-
-    time.sleep(5)
-
-    # compute environments
-    # disable
-    compute_environments = [compute_environment for compute_environment in mgr.compute_environments.keys()]
-    for compute_environment in compute_environments:
-        try:
-            mgr.disable_compute_environment(compute_environment)
-        except Exception:
-            pass
-
-    time.sleep(5)
-
-    # delete
-    while len(compute_environments):
-
-        _compute_environments = copy.copy(compute_environments)
-        for compute_environment in _compute_environments:
-            try:
-                mgr.destroy_compute_environment(compute_environment)
-            except Exception:
-                pass
-            else:
-                compute_environments.remove(compute_environment)
-
-        time.sleep(1)
+#@cli.command(short_help='Teardown all Batch resoures defined in a configuration')
+#@click.pass_context
+#def teardown(ctx):
+#    """
+#    Teardown (destroy/deregister) all Job Descriptions, Job Queues and Compute Environments in a config file
+#    :param ctx:
+#    :return:
+#    """
+#    mgr = BatchManager(filename=ctx.obj['CONFIG_FILE'])
+#    mgr.teardown()
 
 def main():
     cli(obj={})

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -6,7 +6,7 @@ Introduction
 To use ``batchbeagle``, you
 
 * Install ``batchbeagle``
-* Define your queues, compute environments, and job descriptions in ``batchbeagle.yml``
+* Define your queues, compute environments, and job definitions in ``batchbeagle.yml``
 * Use ``beagle`` to start managing them
 
 A simple ``batchbeagle.yml`` looks like this::

--- a/docs/source/quickintro.rst
+++ b/docs/source/quickintro.rst
@@ -2,7 +2,7 @@
 
 * Create, update, disable and destroy queues
 * Create, update, disable and destroy compute environments
-* Create, update, and deregister job descriptions
+* Create, update, and deregister job definitions
 * Submit, list, cancel and terminate jobs
 * Run multiple jobs by passing a parameters file
 * Specify all allowed values for the parameters

--- a/docs/source/yaml.rst
+++ b/docs/source/yaml.rst
@@ -54,7 +54,7 @@ priority
         state: enabled
         priority: 1
 
-computeEnvironmentOrder
+compute_environments
 =======================
 
 (List, Required) The set of compute environments mapped to a job queue and their order relative to each other. The job scheduler uses this parameter to determine which compute environment should execute a given job. Compute environments must be in the VALID state before you can associate them with a job queue. You can associate up to 3 compute environments with a job queue. You must specify both the compute environment name and the order. ::
@@ -230,6 +230,11 @@ minvCpus
 
 (Integer, Required) The minimum number of EC2 vCPUs that an environment should maintain.
 
+desiredvCpus
+------------
+
+(Integer, Optional) The desired number of EC2 vCPUS in the compute environment.
+
 securityGroupIds
 ----------------
 
@@ -244,11 +249,6 @@ tags
 ----
 
 (Dict, Optional) Key-value pair tags to be applied to resources that are launched in the compute environment.
-
-desiredvCpus
-------------
-
-(Integer, Optional) The desired number of EC2 vCPUS in the compute environment.
 
 ec2KeyPair
 ----------
@@ -463,6 +463,7 @@ host
 
 (Dict, Optional) The contents of the host parameter determine whether your data volume persists on the host container instance and where it is stored. If the host parameter is empty, then the Docker daemon assigns a host path for your data volume, but the data is not guaranteed to persist after the containers associated with it stop running.
 
-``sourcePath``
+sourcePath
+^^^^^^^^^^
 
 (String, Optional) The path on the host container instance that is presented to the container. If this parameter is empty, then the Docker daemon has assigned a host path for you. If the host parameter contains a sourcePath file location, then the data volume persists at the specified location on the host container instance until you delete it manually. If the sourcePath value does not exist on the host container instance, the Docker daemon creates it. If the location does exist, the contents of the source path folder are exported.


### PR DESCRIPTION
1. Add `assemble` command to apply a config to AWS Batch. Will create or update compute environments, job queues and job definitions
2. Add `teardown` command to remove from AWS Batch what is in a config. Will terminate jobs, disable and destroy compute environments, job queues and job definitions
3. Add `--nowait` flag to `job submit`
4. Renamed Job Description to Job Definition where appropriate
5. Fix spelling errors