### PR TITLE
Three changes/fixups

### DIFF
--- a/batchbeagle/aws/batch.py
+++ b/batchbeagle/aws/batch.py
@@ -757,6 +757,7 @@ class BatchManager(object):
             print('Submitting Jobs ', end='')
 
             for _parameters in parameter_sets:
+                kwargs['parameters'] = _parameters
                 self.batch.submit_job(**kwargs)
                 jobs_submitted += 1
                 if jobs_submitted % 100 == 0:

--- a/batchbeagle/dplycli.py
+++ b/batchbeagle/dplycli.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import copy
-import csv
 import time
 
 import click
@@ -145,11 +144,7 @@ def submit(ctx, name, job_definition, queue, parameters, nowait):
     """
     mgr = BatchManager(filename=ctx.obj['CONFIG_FILE'])
     if parameters:
-        with open(parameters) as csvfile:
-            # first line is parameter names
-            reader = csv.DictReader(csvfile)
-            for row in reader:
-                mgr.submit_job(name, job_definition, queue, parameters=row)
+        mgr.submit_jobs(name, job_definition, queue, parameters_csv=parameters)
     else:
         mgr.submit_job(name, job_definition, queue)
     while True:


### PR DESCRIPTION
- Share one instance of the AWS Batch client across all consumers.
- Separate handling of parameters job submission into `submit_jobs()`. This gives greater visibility into the job submission process and has the Job Definition only registered once versus every job submission. AWS complained to us that we were maxing out their internal Batch API limits and specifically called out the Job Definition deregister/register cycle per job of a 10k+ rows parameter file
- More verbosity when assembling (`beagle assemble`) and tearing down (`beagle teardown`) Batch resources