### PR TITLE
feat(batch) add new config section - timeout for job definition.

### DIFF
--- a/batchbeagle/aws/batch.py
+++ b/batchbeagle/aws/batch.py
@@ -237,6 +237,7 @@ class JobDefinition(AWSRenderable):
         self.container = JobContainer(yml['container'])
         self.parameters = yml.get('parameters', None)
         self.retryStrategy = yml.get('retryStrategy', None)
+        self.timeout = yml.get('timeout', None)
 
     def load_render(self, update):
         self._add_key('jobDefinitionName', self.name)
@@ -244,6 +245,7 @@ class JobDefinition(AWSRenderable):
         self._add_key('containerProperties', self.container.render(update))
         self._add_key('parameters')
         self._add_key('retryStrategy')
+        self._add_key('timeout')
 
     def _get_all_active(self):
         active = []
@@ -321,6 +323,9 @@ class JobDefinition(AWSRenderable):
         if self.retryStrategy:
             description.append("Retry Strategy")
             description.append("  attempts: {}".format(self.retryStrategy['attempts']))
+        if self.timeout:
+            description.append("Timeout")
+            description.append("  attemptDurationSeconds: {}".format(self.timeout['attemptDurationSeconds']))
         return description
 
 

--- a/docs/source/yaml.rst
+++ b/docs/source/yaml.rst
@@ -316,6 +316,21 @@ attempts
 
 (Integer, Optional) The number of times to move a job to the RUNNABLE status. You may specify between 1 and 10 attempts. If attempts is greater than one, the job is retried if it fails until it has moved to RUNNABLE that many times.
 
+timeout
+=============
+
+You can configure a timeout duration for your jobs so that if a job runs longer than that, AWS Batch terminates the job. ::
+
+    job_definitions:
+      - name: job1
+        timeout:
+            attemptDurationSeconds: 300
+
+attemptDurationSeconds
+--------
+
+(Integer, Optional) The time duration in seconds after which AWS Batch terminates your jobs if they have not finished. The minimum value for the timeout is 60 seconds.
+
 container
 =========
 


### PR DESCRIPTION
AWS batch job definition provides config sections about setup execution timeout (https://docs.aws.amazon.com/en_us/batch/latest/userguide/job_timeouts.html), which is missing in batchbeagle.